### PR TITLE
don't use PkgPath in resolving code

### DIFF
--- a/pkgload.go
+++ b/pkgload.go
@@ -94,7 +94,7 @@ func VisitUnits(pkgs []*packages.Package, visit func(*Unit)) {
 
 	for _, pkg := range pkgs {
 		switch {
-		case strings.HasSuffix(pkg.PkgPath, "_test"):
+		case strings.HasSuffix(pkg.Name, "_test"):
 			key := withoutSuffix(pkg.PkgPath, "_test")
 			u := internUnit(key)
 			mustBeNil(u.ExternalTest)
@@ -103,7 +103,7 @@ func VisitUnits(pkgs []*packages.Package, visit func(*Unit)) {
 			u := internUnit(pkg.PkgPath)
 			mustBeNil(u.Test)
 			u.Test = pkg
-		case pkg.Name == "main" && strings.HasSuffix(pkg.PkgPath, ".test"):
+		case pkg.Name == "main" && strings.HasSuffix(pkg.ID, ".test"):
 			key := withoutSuffix(pkg.PkgPath, ".text")
 			u := internUnit(key)
 			mustBeNil(u.TestBinary)

--- a/pkgload_test.go
+++ b/pkgload_test.go
@@ -25,6 +25,11 @@ func TestVisitUnits(t *testing.T) {
 		{"./testdata/empty", ""},
 		{"./testdata/main_only", "Base"},
 		{"./testdata/main_with_tests", "Base+Test+TestBinary"},
+
+		{"./testdata/horrors/base-only/blah.test", "Base"},
+		{"./testdata/horrors/base-only/blah_test", "Base"},
+		{"./testdata/horrors/base-with-tests/blah.test", "Base+Test+TestBinary"},
+		{"./testdata/horrors/base-with-tests/blah_test", "Base+Test+TestBinary"},
 	}
 
 	checkFields := func(desc string, u *Unit) error {

--- a/testdata/horrors/base-only/blah.test/base.go
+++ b/testdata/horrors/base-only/blah.test/base.go
@@ -1,0 +1,3 @@
+package blah
+
+func F() {}

--- a/testdata/horrors/base-only/blah_test/base.go
+++ b/testdata/horrors/base-only/blah_test/base.go
@@ -1,0 +1,3 @@
+package blah
+
+func F() {}

--- a/testdata/horrors/base-with-tests/blah.test/base.go
+++ b/testdata/horrors/base-with-tests/blah.test/base.go
@@ -1,0 +1,1 @@
+package blah

--- a/testdata/horrors/base-with-tests/blah.test/base_test.go
+++ b/testdata/horrors/base-with-tests/blah.test/base_test.go
@@ -1,0 +1,5 @@
+package blah
+
+import "testing"
+
+func Test(t *testing.T) {}

--- a/testdata/horrors/base-with-tests/blah_test/base.go
+++ b/testdata/horrors/base-with-tests/blah_test/base.go
@@ -1,0 +1,1 @@
+package blah

--- a/testdata/horrors/base-with-tests/blah_test/base_test.go
+++ b/testdata/horrors/base-with-tests/blah_test/base_test.go
@@ -1,0 +1,5 @@
+package blah
+
+import "testing"
+
+func Test(t *testing.T) {}


### PR DESCRIPTION
Packages with paths that end with "_test" or ".test" are
problematic if that determines how package contents
are interpreted. Use ID and Name for that instead.

Updates #5

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>